### PR TITLE
Path separator issue and StringUtils optimization

### DIFF
--- a/BSLegacyUtil/Program.cs
+++ b/BSLegacyUtil/Program.cs
@@ -191,7 +191,7 @@ public abstract class Program {
                 
                 Process.Start(new ProcessStartInfo {
                     WorkingDirectory = bsDir,
-                    FileName = $"{bsDir}{Path.PathSeparator}IPA.exe"
+                    FileName = $"{bsDir}{Path.DirectorySeparatorChar}IPA.exe"
                 });
                 
                 if (!isOldSelected) {
@@ -241,7 +241,7 @@ public abstract class Program {
     private static void PlayGame(bool oculus = false) {
         var p = new Process();
         var temp = Path.Combine(Vars.BaseDirectory, "Installed Versions", $"Beat Saber {LocalJsonModel.TheConfig!.RememberedVersion}");
-        p.StartInfo = new ProcessStartInfo($"{temp}{Path.PathSeparator}Beat Saber.exe", oculus ? "-vrmode oculus" : "") {
+        p.StartInfo = new ProcessStartInfo($"{temp}{Path.DirectorySeparatorChar}Beat Saber.exe", oculus ? "-vrmode oculus" : "") {
             UseShellExecute = false,
             WorkingDirectory = temp
         };

--- a/BSLegacyUtil/Utils/StringUtils.cs
+++ b/BSLegacyUtil/Utils/StringUtils.cs
@@ -1,13 +1,8 @@
 ﻿namespace BSLegacyUtil.Utils; 
 
 public static class StringUtils {
-    public static bool ContainsMultiple(this string str1, string str2, string str3) => str1.Contains(str2) || str1.Contains(str3);
-    public static bool ContainsMultiple(this string str1, string str2, string str3, string str4) => str1.Contains(str2) || str1.Contains(str3) || str1.Contains(str4);
-    public static bool ContainsMultiple(this string str1, string str2, string str3, string str4, string str5) => str1.Contains(str2) || str1.Contains(str3) || str1.Contains(str4) || str1.Contains(str5);
-    
-    public static bool EqualsMultiple(this string str1, string str2, string str3) => str1.Equals(str2) || str1.Equals(str3);
-    public static bool EqualsMultiple(this string str1, string str2, string str3, string str4) => str1.Equals(str2) || str1.Equals(str3) || str1.Equals(str4);
-    public static bool EqualsMultiple(this string str1, string str2, string str3, string str4, string str5) => str1.Equals(str2) || str1.Equals(str3) || str1.Equals(str4) || str1.Equals(str5);
+    public static bool ContainsMultiple(this string str1, params string[] strs) => strs.Any(str1.Contains);
+    public static bool EqualsMultiple(this string str1, params string[] strs) => strs.Any(str1.Equals);
     
     public static string ReplaceAll(this string theStringToBeEdited, string oldCharacters, string newCharacters) // Idea from Java String.ReplaceAll()
         => oldCharacters.ToCharArray().Aggregate(theStringToBeEdited, (current, c) => current.Replace($"{c}", newCharacters));

--- a/BSLegacyUtil/Vars.cs
+++ b/BSLegacyUtil/Vars.cs
@@ -13,7 +13,7 @@ public static class Vars {
 #else
     public static bool IsDebug { get; set; }
 #endif
-    public static string BaseDirectory { get; internal set; } = IsWindows ? Environment.CurrentDirectory + Path.PathSeparator : AppDomain.CurrentDomain.BaseDirectory;
+    public static string BaseDirectory { get; internal set; } = IsWindows ? Environment.CurrentDirectory + Path.DirectorySeparatorChar : AppDomain.CurrentDomain.BaseDirectory;
     
     /*===============================================*/
     public static string SteamPassword { get; internal set; } = "";


### PR DESCRIPTION
In the current version of the tool, any feature that uses `Path.PathSeparator` in some way fails to run on my machine. The reason for this is that this field is used to separate multiple paths, not the directories in a single path. On my Windows 11 PC, the value evaluates to ";".

The `Path.DirectorySeperatorChar` would be more suitable to use, as that field evaluates to "\" on Windows, and "/" on UNIX like systems.

For `StringUtils`, I have rewritten some of the methods to allow an arbitrary amount of parameters without having to write a new method for each different amount.

The most important part for me is the path separator changes, as that fix is required to make the tool run on my system, so if the `StringUtil` changes are not wanted, feel free to discard those changes.